### PR TITLE
Explicitly close connection

### DIFF
--- a/net.go
+++ b/net.go
@@ -156,6 +156,7 @@ func (t *TCPTransport) getConn(host string) (*tcpOutConn, error) {
 		if _, err := out.sock.Read(nil); err == nil {
 			return out, nil
 		}
+		out.sock.Close()
 	}
 
 	// Try to establish a connection


### PR DESCRIPTION
Explicitly close the connection when a `Read(nil)` produces an error.