### PR TITLE
Handle nil Notify target - causes a panic

### DIFF
--- a/net.go
+++ b/net.go
@@ -723,6 +723,9 @@ func (t *TCPTransport) handleConn(conn *net.TCPConn) {
 				log.Printf("[ERR] Failed to decode TCP body! Got %s", err)
 				return
 			}
+			if body.Target == nil {
+				return
+			}
 
 			// Generate a response
 			obj, ok := t.get(body.Target)


### PR DESCRIPTION
A `nil` target in the `Notify` body causes the server to panic as it isn't caught.  The current logic essentially closes the connection when a `nil` target is received.