### PR TITLE
Fix test logs for go 1.10

### DIFF
--- a/transport_test.go
+++ b/transport_test.go
@@ -62,7 +62,7 @@ func TestLocalList(t *testing.T) {
 		t.Fatalf("unexpected err. %s", err)
 	}
 	if len(list) != 1 || list[0] != vn {
-		t.Fatalf("local list failed", list)
+		t.Fatalf("local list failed %v", list)
 	}
 }
 

--- a/vnode_test.go
+++ b/vnode_test.go
@@ -154,11 +154,11 @@ func TestVnodeCheckNewSuccDead(t *testing.T) {
 	vn1.successors[0] = &Vnode{Id: []byte{0}}
 
 	if err := vn1.checkNewSuccessor(); err == nil {
-		t.Fatalf("err!", err)
+		t.Fatalf("err! %v", err)
 	}
 
 	if vn1.successors[0].String() != "00" {
-		t.Fatalf("unexpected successor!")
+		t.Fatal("unexpected successor!")
 	}
 }
 


### PR DESCRIPTION
Fix trivial test log formatting errors