### PR TITLE
fix: lint and use go.mod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,5 @@ test:
 	go test .
 
 cov:
-	gocov test github.com/armon/go-chord | gocov-html > /tmp/coverage.html
-	open /tmp/coverage.html
-
+	go test -coverprofile=/tmp/coverage.out .
+	go tool cover -html=/tmp/coverage.out

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/euforia/go-chord
+
+go 1.14

--- a/iter_closest.go
+++ b/iter_closest.go
@@ -5,95 +5,94 @@ import (
 )
 
 type closestPreceedingVnodeIterator struct {
-	key           []byte
-	vn            *localVnode
-	finger_idx    int
-	successor_idx int
-	yielded       map[string]struct{}
+	key          []byte
+	vn           *localVnode
+	fingerIdx    int
+	successorIdx int
+	yielded      map[string]struct{}
 }
 
 func (cp *closestPreceedingVnodeIterator) init(vn *localVnode, key []byte) {
 	cp.key = key
 	cp.vn = vn
-	cp.successor_idx = len(vn.successors) - 1
-	cp.finger_idx = len(vn.finger) - 1
+	cp.successorIdx = len(vn.successors) - 1
+	cp.fingerIdx = len(vn.finger) - 1
 	cp.yielded = make(map[string]struct{})
 }
 
 func (cp *closestPreceedingVnodeIterator) Next() *Vnode {
 	// Try to find each node
-	var successor_node *Vnode
-	var finger_node *Vnode
+	var successorNode *Vnode
+	var fingerNode *Vnode
 
 	// Scan to find the next successor
 	vn := cp.vn
 	var i int
-	for i = cp.successor_idx; i >= 0; i-- {
+	for i = cp.successorIdx; i >= 0; i-- {
 		if vn.successors[i] == nil {
 			continue
 		}
 		if _, ok := cp.yielded[vn.successors[i].String()]; ok {
 			continue
 		}
-		if between(vn.Id, cp.key, vn.successors[i].Id) {
-			successor_node = vn.successors[i]
+		if between(vn.ID, cp.key, vn.successors[i].ID) {
+			successorNode = vn.successors[i]
 			break
 		}
 	}
-	cp.successor_idx = i
+	cp.successorIdx = i
 
 	// Scan to find the next finger
-	for i = cp.finger_idx; i >= 0; i-- {
+	for i = cp.fingerIdx; i >= 0; i-- {
 		if vn.finger[i] == nil {
 			continue
 		}
 		if _, ok := cp.yielded[vn.finger[i].String()]; ok {
 			continue
 		}
-		if between(vn.Id, cp.key, vn.finger[i].Id) {
-			finger_node = vn.finger[i]
+		if between(vn.ID, cp.key, vn.finger[i].ID) {
+			fingerNode = vn.finger[i]
 			break
 		}
 	}
-	cp.finger_idx = i
+	cp.fingerIdx = i
 
 	// Determine which node is better
-	if successor_node != nil && finger_node != nil {
+	if successorNode != nil && fingerNode != nil {
 		// Determine the closer node
 		hb := cp.vn.ring.config.hashBits
-		closest := closest_preceeding_vnode(successor_node,
-			finger_node, cp.key, hb)
-		if closest == successor_node {
-			cp.successor_idx--
+		closest := closestPreceedingVnode(successorNode,
+			fingerNode, cp.key, hb)
+		if closest == successorNode {
+			cp.successorIdx--
 		} else {
-			cp.finger_idx--
+			cp.fingerIdx--
 		}
 		cp.yielded[closest.String()] = struct{}{}
 		return closest
 
-	} else if successor_node != nil {
-		cp.successor_idx--
-		cp.yielded[successor_node.String()] = struct{}{}
-		return successor_node
+	} else if successorNode != nil {
+		cp.successorIdx--
+		cp.yielded[successorNode.String()] = struct{}{}
+		return successorNode
 
-	} else if finger_node != nil {
-		cp.finger_idx--
-		cp.yielded[finger_node.String()] = struct{}{}
-		return finger_node
+	} else if fingerNode != nil {
+		cp.fingerIdx--
+		cp.yielded[fingerNode.String()] = struct{}{}
+		return fingerNode
 	}
 
 	return nil
 }
 
 // Returns the closest preceeding Vnode to the key
-func closest_preceeding_vnode(a, b *Vnode, key []byte, bits int) *Vnode {
-	a_dist := distance(a.Id, key, bits)
-	b_dist := distance(b.Id, key, bits)
-	if a_dist.Cmp(b_dist) <= 0 {
+func closestPreceedingVnode(a, b *Vnode, key []byte, bits int) *Vnode {
+	adist := distance(a.ID, key, bits)
+	bdist := distance(b.ID, key, bits)
+	if adist.Cmp(bdist) <= 0 {
 		return a
-	} else {
-		return b
 	}
+	return b
 }
 
 // Computes the forward distance from a to b modulus a ring size
@@ -103,13 +102,13 @@ func distance(a, b []byte, bits int) *big.Int {
 	ring.Exp(big.NewInt(2), big.NewInt(int64(bits)), nil)
 
 	// Convert to int
-	var a_int, b_int big.Int
-	(&a_int).SetBytes(a)
-	(&b_int).SetBytes(b)
+	var aint, bint big.Int
+	(&aint).SetBytes(a)
+	(&bint).SetBytes(b)
 
 	// Compute the distances
 	var dist big.Int
-	(&dist).Sub(&b_int, &a_int)
+	(&dist).Sub(&bint, &aint)
 
 	// Distance modulus ring size
 	(&dist).Mod(&dist, &ring)

--- a/iter_closest_test.go
+++ b/iter_closest_test.go
@@ -7,17 +7,17 @@ import (
 
 func TestNextClosest(t *testing.T) {
 	// Make the vnodes on the ring (mod 64)
-	v1 := &Vnode{Id: []byte{1}}
-	v2 := &Vnode{Id: []byte{10}}
-	//v3 := &Vnode{Id: []byte{20}}
-	v4 := &Vnode{Id: []byte{32}}
-	//v5 := &Vnode{Id: []byte{40}}
-	v6 := &Vnode{Id: []byte{59}}
-	v7 := &Vnode{Id: []byte{62}}
+	v1 := &Vnode{ID: []byte{1}}
+	v2 := &Vnode{ID: []byte{10}}
+	//v3 := &Vnode{ID: []byte{20}}
+	v4 := &Vnode{ID: []byte{32}}
+	//v5 := &Vnode{ID: []byte{40}}
+	v6 := &Vnode{ID: []byte{59}}
+	v7 := &Vnode{ID: []byte{62}}
 
 	// Make a vnode
 	vn := &localVnode{}
-	vn.Id = []byte{54}
+	vn.ID = []byte{54}
 	vn.successors = []*Vnode{v6, v7, nil}
 	vn.finger = []*Vnode{v6, v6, v7, v1, v2, v4, nil}
 	vn.ring = &Ring{}
@@ -57,17 +57,17 @@ func TestNextClosest(t *testing.T) {
 
 func TestNextClosestNoSucc(t *testing.T) {
 	// Make the vnodes on the ring (mod 64)
-	v1 := &Vnode{Id: []byte{1}}
-	v2 := &Vnode{Id: []byte{10}}
-	//v3 := &Vnode{Id: []byte{20}}
-	v4 := &Vnode{Id: []byte{32}}
-	//v5 := &Vnode{Id: []byte{40}}
-	v6 := &Vnode{Id: []byte{59}}
-	v7 := &Vnode{Id: []byte{62}}
+	v1 := &Vnode{ID: []byte{1}}
+	v2 := &Vnode{ID: []byte{10}}
+	//v3 := &Vnode{ID: []byte{20}}
+	v4 := &Vnode{ID: []byte{32}}
+	//v5 := &Vnode{ID: []byte{40}}
+	v6 := &Vnode{ID: []byte{59}}
+	v7 := &Vnode{ID: []byte{62}}
 
 	// Make a vnode
 	vn := &localVnode{}
-	vn.Id = []byte{54}
+	vn.ID = []byte{54}
 	vn.successors = []*Vnode{nil}
 	vn.finger = []*Vnode{v6, v6, v7, v1, v2, v4, nil}
 	vn.ring = &Ring{}
@@ -107,17 +107,17 @@ func TestNextClosestNoSucc(t *testing.T) {
 
 func TestNextClosestNoFinger(t *testing.T) {
 	// Make the vnodes on the ring (mod 64)
-	//v1 := &Vnode{Id: []byte{1}}
-	//v2 := &Vnode{Id: []byte{10}}
-	//v3 := &Vnode{Id: []byte{20}}
-	//v4 := &Vnode{Id: []byte{32}}
-	//v5 := &Vnode{Id: []byte{40}}
-	v6 := &Vnode{Id: []byte{59}}
-	v7 := &Vnode{Id: []byte{62}}
+	//v1 := &Vnode{ID: []byte{1}}
+	//v2 := &Vnode{ID: []byte{10}}
+	//v3 := &Vnode{ID: []byte{20}}
+	//v4 := &Vnode{ID: []byte{32}}
+	//v5 := &Vnode{ID: []byte{40}}
+	v6 := &Vnode{ID: []byte{59}}
+	v7 := &Vnode{ID: []byte{62}}
 
 	// Make a vnode
 	vn := &localVnode{}
-	vn.Id = []byte{54}
+	vn.ID = []byte{54}
 	vn.successors = []*Vnode{v6, v7, v7, nil}
 	vn.finger = []*Vnode{nil, nil, nil}
 	vn.ring = &Ring{}
@@ -146,14 +146,14 @@ func TestNextClosestNoFinger(t *testing.T) {
 }
 
 func TestClosest(t *testing.T) {
-	a := &Vnode{Id: []byte{128}}
-	b := &Vnode{Id: []byte{32}}
+	a := &Vnode{ID: []byte{128}}
+	b := &Vnode{ID: []byte{32}}
 	k := []byte{45}
-	c := closest_preceeding_vnode(a, b, k, 8)
+	c := closestPreceedingVnode(a, b, k, 8)
 	if c != b {
 		t.Fatalf("expect b to be closer!")
 	}
-	c = closest_preceeding_vnode(b, a, k, 8)
+	c = closestPreceedingVnode(b, a, k, 8)
 	if c != b {
 		t.Fatalf("expect b to be closer!")
 	}

--- a/ring.go
+++ b/ring.go
@@ -33,7 +33,7 @@ func (r *Ring) Len() int {
 // Less returns whether the vnode with index i should sort
 // before the vnode with index j.
 func (r *Ring) Less(i, j int) bool {
-	return bytes.Compare(r.vnodes[i].Id, r.vnodes[j].Id) == -1
+	return bytes.Compare(r.vnodes[i].ID, r.vnodes[j].ID) == -1
 }
 
 // Swap swaps the vnodes with indexes i and j.
@@ -44,7 +44,7 @@ func (r *Ring) Swap(i, j int) {
 // Returns the nearest local vnode to the key
 func (r *Ring) nearestVnode(key []byte) *localVnode {
 	for i := len(r.vnodes) - 1; i >= 0; i-- {
-		if bytes.Compare(r.vnodes[i].Id, key) == -1 {
+		if bytes.Compare(r.vnodes[i].ID, key) == -1 {
 			return r.vnodes[i]
 		}
 	}

--- a/ring_test.go
+++ b/ring_test.go
@@ -61,7 +61,7 @@ func TestRingInit(t *testing.T) {
 		if ring.vnodes[i].ring != ring {
 			t.Fatalf("ring missing!")
 		}
-		if ring.vnodes[i].Id == nil {
+		if ring.vnodes[i].ID == nil {
 			t.Fatalf("ID not initialized!")
 		}
 	}
@@ -77,27 +77,27 @@ func TestRingLen(t *testing.T) {
 func TestRingSort(t *testing.T) {
 	ring := makeRing()
 	sort.Sort(ring)
-	if bytes.Compare(ring.vnodes[0].Id, ring.vnodes[1].Id) != -1 {
+	if bytes.Compare(ring.vnodes[0].ID, ring.vnodes[1].ID) != -1 {
 		t.Fatalf("bad sort")
 	}
-	if bytes.Compare(ring.vnodes[1].Id, ring.vnodes[2].Id) != -1 {
+	if bytes.Compare(ring.vnodes[1].ID, ring.vnodes[2].ID) != -1 {
 		t.Fatalf("bad sort")
 	}
-	if bytes.Compare(ring.vnodes[2].Id, ring.vnodes[3].Id) != -1 {
+	if bytes.Compare(ring.vnodes[2].ID, ring.vnodes[3].ID) != -1 {
 		t.Fatalf("bad sort")
 	}
-	if bytes.Compare(ring.vnodes[3].Id, ring.vnodes[4].Id) != -1 {
+	if bytes.Compare(ring.vnodes[3].ID, ring.vnodes[4].ID) != -1 {
 		t.Fatalf("bad sort")
 	}
 }
 
 func TestRingNearest(t *testing.T) {
 	ring := makeRing()
-	ring.vnodes[0].Id = []byte{2}
-	ring.vnodes[1].Id = []byte{4}
-	ring.vnodes[2].Id = []byte{7}
-	ring.vnodes[3].Id = []byte{10}
-	ring.vnodes[4].Id = []byte{14}
+	ring.vnodes[0].ID = []byte{2}
+	ring.vnodes[1].ID = []byte{4}
+	ring.vnodes[2].ID = []byte{7}
+	ring.vnodes[3].ID = []byte{10}
+	ring.vnodes[4].ID = []byte{14}
 	key := []byte{6}
 
 	near := ring.nearestVnode(key)

--- a/transport.go
+++ b/transport.go
@@ -21,7 +21,7 @@ type LocalTransport struct {
 	local  map[string]*localRPC
 }
 
-// Creates a local transport to wrap a remote transport
+// InitLocalTransport creates a local transport to wrap a remote transport
 func InitLocalTransport(remote Transport) Transport {
 	// Replace a nil transport with black hole
 	if remote == nil {
@@ -40,11 +40,11 @@ func (lt *LocalTransport) get(vn *Vnode) (VnodeRPC, bool) {
 	w, ok := lt.local[key]
 	if ok {
 		return w.obj, ok
-	} else {
-		return nil, ok
 	}
+	return nil, ok
 }
 
+// ListVnodes .
 func (lt *LocalTransport) ListVnodes(host string) ([]*Vnode, error) {
 	// Check if this is a local host
 	if host == lt.host {
@@ -65,6 +65,7 @@ func (lt *LocalTransport) ListVnodes(host string) ([]*Vnode, error) {
 	return lt.remote.ListVnodes(host)
 }
 
+// Ping .
 func (lt *LocalTransport) Ping(vn *Vnode) (bool, error) {
 	// Look for it locally
 	_, ok := lt.get(vn)
@@ -78,6 +79,7 @@ func (lt *LocalTransport) Ping(vn *Vnode) (bool, error) {
 	return lt.remote.Ping(vn)
 }
 
+// GetPredecessor satisifies the Transport interface
 func (lt *LocalTransport) GetPredecessor(vn *Vnode) (*Vnode, error) {
 	// Look for it locally
 	obj, ok := lt.get(vn)
@@ -91,6 +93,7 @@ func (lt *LocalTransport) GetPredecessor(vn *Vnode) (*Vnode, error) {
 	return lt.remote.GetPredecessor(vn)
 }
 
+// Notify satisifies the Transport interface
 func (lt *LocalTransport) Notify(vn, self *Vnode) ([]*Vnode, error) {
 	// Look for it locally
 	obj, ok := lt.get(vn)
@@ -104,6 +107,7 @@ func (lt *LocalTransport) Notify(vn, self *Vnode) ([]*Vnode, error) {
 	return lt.remote.Notify(vn, self)
 }
 
+// FindSuccessors satisifies the Transport interface
 func (lt *LocalTransport) FindSuccessors(vn *Vnode, n int, key []byte) ([]*Vnode, error) {
 	// Look for it locally
 	obj, ok := lt.get(vn)
@@ -117,6 +121,7 @@ func (lt *LocalTransport) FindSuccessors(vn *Vnode, n int, key []byte) ([]*Vnode
 	return lt.remote.FindSuccessors(vn, n, key)
 }
 
+// ClearPredecessor satisifies the Transport interface
 func (lt *LocalTransport) ClearPredecessor(target, self *Vnode) error {
 	// Look for it locally
 	obj, ok := lt.get(target)
@@ -130,6 +135,7 @@ func (lt *LocalTransport) ClearPredecessor(target, self *Vnode) error {
 	return lt.remote.ClearPredecessor(target, self)
 }
 
+// SkipSuccessor satisifies the Transport interface
 func (lt *LocalTransport) SkipSuccessor(target, self *Vnode) error {
 	// Look for it locally
 	obj, ok := lt.get(target)
@@ -143,6 +149,7 @@ func (lt *LocalTransport) SkipSuccessor(target, self *Vnode) error {
 	return lt.remote.SkipSuccessor(target, self)
 }
 
+// Register satisifies the Transport interface
 func (lt *LocalTransport) Register(v *Vnode, o VnodeRPC) {
 	// Register local instance
 	key := v.String()
@@ -155,6 +162,7 @@ func (lt *LocalTransport) Register(v *Vnode, o VnodeRPC) {
 	lt.remote.Register(v, o)
 }
 
+// Deregister ...
 func (lt *LocalTransport) Deregister(v *Vnode) {
 	key := v.String()
 	lt.lock.Lock()
@@ -162,38 +170,50 @@ func (lt *LocalTransport) Deregister(v *Vnode) {
 	lt.lock.Unlock()
 }
 
+var (
+	blackHoleConnectErrStr = "blackhole transport failed to connect: %s"
+)
+
 // BlackholeTransport is used to provide an implemenation of the Transport that
 // does not actually do anything. Any operation will result in an error.
 type BlackholeTransport struct {
 }
 
+// ListVnodes satisifies the Transport interface
 func (*BlackholeTransport) ListVnodes(host string) ([]*Vnode, error) {
-	return nil, fmt.Errorf("Failed to connect! Blackhole: %s.", host)
+	return nil, fmt.Errorf(blackHoleConnectErrStr, host)
 }
 
+// Ping satisifies the Transport interface
 func (*BlackholeTransport) Ping(vn *Vnode) (bool, error) {
 	return false, nil
 }
 
+// GetPredecessor atisifies the Transport interface
 func (*BlackholeTransport) GetPredecessor(vn *Vnode) (*Vnode, error) {
-	return nil, fmt.Errorf("Failed to connect! Blackhole: %s.", vn.String())
+	return nil, fmt.Errorf(blackHoleConnectErrStr, vn.String())
 }
 
+// Notify satisifies the Transport interface
 func (*BlackholeTransport) Notify(vn, self *Vnode) ([]*Vnode, error) {
-	return nil, fmt.Errorf("Failed to connect! Blackhole: %s", vn.String())
+	return nil, fmt.Errorf(blackHoleConnectErrStr, vn.String())
 }
 
+// FindSuccessors satisifies the Transport interface
 func (*BlackholeTransport) FindSuccessors(vn *Vnode, n int, key []byte) ([]*Vnode, error) {
-	return nil, fmt.Errorf("Failed to connect! Blackhole: %s", vn.String())
+	return nil, fmt.Errorf(blackHoleConnectErrStr, vn.String())
 }
 
+// ClearPredecessor satisifies the Transport interface
 func (*BlackholeTransport) ClearPredecessor(target, self *Vnode) error {
-	return fmt.Errorf("Failed to connect! Blackhole: %s", target.String())
+	return fmt.Errorf(blackHoleConnectErrStr, target.String())
 }
 
+// SkipSuccessor satisifies the Transport interface
 func (*BlackholeTransport) SkipSuccessor(target, self *Vnode) error {
-	return fmt.Errorf("Failed to connect! Blackhole: %s", target.String())
+	return fmt.Errorf(blackHoleConnectErrStr, target.String())
 }
 
+// Register satisifies the Transport interface
 func (*BlackholeTransport) Register(v *Vnode, o VnodeRPC) {
 }

--- a/transport_test.go
+++ b/transport_test.go
@@ -2,25 +2,26 @@ package chord
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 )
 
 type MockVnodeRPC struct {
-	err       error
-	pred      *Vnode
-	not_pred  *Vnode
-	succ_list []*Vnode
-	key       []byte
-	succ      []*Vnode
-	skip      *Vnode
+	err      error
+	pred     *Vnode
+	notPred  *Vnode
+	succList []*Vnode
+	key      []byte
+	succ     []*Vnode
+	skip     *Vnode
 }
 
 func (mv *MockVnodeRPC) GetPredecessor() (*Vnode, error) {
 	return mv.pred, mv.err
 }
 func (mv *MockVnodeRPC) Notify(vn *Vnode) ([]*Vnode, error) {
-	mv.not_pred = vn
-	return mv.succ_list, mv.err
+	mv.notPred = vn
+	return mv.succList, mv.err
 }
 func (mv *MockVnodeRPC) FindSuccessors(n int, key []byte) ([]*Vnode, error) {
 	mv.key = key
@@ -53,7 +54,7 @@ func TestInitLocalTransport(t *testing.T) {
 
 func TestLocalList(t *testing.T) {
 	l := makeLocal()
-	vn := &Vnode{Id: []byte{1}, Host: "test"}
+	vn := &Vnode{ID: []byte{1}, Host: "test"}
 	mockVN := &MockVnodeRPC{}
 	l.Register(vn, mockVN)
 
@@ -62,13 +63,13 @@ func TestLocalList(t *testing.T) {
 		t.Fatalf("unexpected err. %s", err)
 	}
 	if len(list) != 1 || list[0] != vn {
-		t.Fatalf("local list failed", list)
+		t.Fatalf("local list failed %v", list)
 	}
 }
 
 func TestLocalListRemote(t *testing.T) {
 	l := makeLocal()
-	vn := &Vnode{Id: []byte{1}, Host: "test"}
+	vn := &Vnode{ID: []byte{1}, Host: "test"}
 	mockVN := &MockVnodeRPC{}
 	l.Register(vn, mockVN)
 
@@ -80,7 +81,7 @@ func TestLocalListRemote(t *testing.T) {
 
 func TestLocalPing(t *testing.T) {
 	l := makeLocal()
-	vn := &Vnode{Id: []byte{1}}
+	vn := &Vnode{ID: []byte{1}}
 	mockVN := &MockVnodeRPC{}
 	l.Register(vn, mockVN)
 	if res, err := l.Ping(vn); !res || err != nil {
@@ -90,12 +91,12 @@ func TestLocalPing(t *testing.T) {
 
 func TestLocalMissingPing(t *testing.T) {
 	l := makeLocal()
-	vn := &Vnode{Id: []byte{2}}
+	vn := &Vnode{ID: []byte{2}}
 	mockVN := &MockVnodeRPC{}
 	l.Register(vn, mockVN)
 
 	// Print some random node
-	vn2 := &Vnode{Id: []byte{3}}
+	vn2 := &Vnode{ID: []byte{3}}
 	if res, _ := l.Ping(vn2); res {
 		t.Fatalf("ping succeeded")
 	}
@@ -103,12 +104,12 @@ func TestLocalMissingPing(t *testing.T) {
 
 func TestLocalGetPredecessor(t *testing.T) {
 	l := makeLocal()
-	pred := &Vnode{Id: []byte{10}}
-	vn := &Vnode{Id: []byte{42}}
+	pred := &Vnode{ID: []byte{10}}
+	vn := &Vnode{ID: []byte{42}}
 	mockVN := &MockVnodeRPC{pred: pred, err: nil}
 	l.Register(vn, mockVN)
 
-	vn2 := &Vnode{Id: []byte{42}}
+	vn2 := &Vnode{ID: []byte{42}}
 	res, err := l.GetPredecessor(vn2)
 	if err != nil {
 		t.Fatalf("local GetPredecessor failed")
@@ -117,7 +118,7 @@ func TestLocalGetPredecessor(t *testing.T) {
 		t.Fatalf("got wrong predecessor")
 	}
 
-	unknown := &Vnode{Id: []byte{1}}
+	unknown := &Vnode{ID: []byte{1}}
 	res, err = l.GetPredecessor(unknown)
 	if err == nil {
 		t.Fatalf("expected error!")
@@ -126,16 +127,16 @@ func TestLocalGetPredecessor(t *testing.T) {
 
 func TestLocalNotify(t *testing.T) {
 	l := makeLocal()
-	suc1 := &Vnode{Id: []byte{10}}
-	suc2 := &Vnode{Id: []byte{20}}
-	suc3 := &Vnode{Id: []byte{30}}
-	succ_list := []*Vnode{suc1, suc2, suc3}
+	suc1 := &Vnode{ID: []byte{10}}
+	suc2 := &Vnode{ID: []byte{20}}
+	suc3 := &Vnode{ID: []byte{30}}
+	succList := []*Vnode{suc1, suc2, suc3}
 
-	mockVN := &MockVnodeRPC{succ_list: succ_list, err: nil}
-	vn := &Vnode{Id: []byte{0}}
+	mockVN := &MockVnodeRPC{succList: succList, err: nil}
+	vn := &Vnode{ID: []byte{0}}
 	l.Register(vn, mockVN)
 
-	self := &Vnode{Id: []byte{60}}
+	self := &Vnode{ID: []byte{60}}
 	res, err := l.Notify(vn, self)
 	if err != nil {
 		t.Fatalf("local notify failed")
@@ -143,11 +144,11 @@ func TestLocalNotify(t *testing.T) {
 	if res == nil || res[0] != suc1 || res[1] != suc2 || res[2] != suc3 {
 		t.Fatalf("got wrong successor list")
 	}
-	if mockVN.not_pred != self {
+	if mockVN.notPred != self {
 		t.Fatalf("didn't get notified correctly!")
 	}
 
-	unknown := &Vnode{Id: []byte{1}}
+	unknown := &Vnode{ID: []byte{1}}
 	res, err = l.Notify(unknown, self)
 	if err == nil {
 		t.Fatalf("remote notify should fail")
@@ -156,10 +157,10 @@ func TestLocalNotify(t *testing.T) {
 
 func TestLocalFindSucc(t *testing.T) {
 	l := makeLocal()
-	suc := []*Vnode{&Vnode{Id: []byte{40}}}
+	suc := []*Vnode{{ID: []byte{40}}}
 
 	mockVN := &MockVnodeRPC{succ: suc, err: nil}
-	vn := &Vnode{Id: []byte{12}}
+	vn := &Vnode{ID: []byte{12}}
 	l.Register(vn, mockVN)
 
 	key := []byte("test")
@@ -174,7 +175,7 @@ func TestLocalFindSucc(t *testing.T) {
 		t.Fatalf("didn't get key correctly!")
 	}
 
-	unknown := &Vnode{Id: []byte{1}}
+	unknown := &Vnode{ID: []byte{1}}
 	res, err = l.FindSuccessors(unknown, 1, key)
 	if err == nil {
 		t.Fatalf("remote find should fail")
@@ -183,9 +184,9 @@ func TestLocalFindSucc(t *testing.T) {
 
 func TestLocalClearPred(t *testing.T) {
 	l := makeLocal()
-	pred := &Vnode{Id: []byte{10}}
+	pred := &Vnode{ID: []byte{10}}
 	mockVN := &MockVnodeRPC{pred: pred}
-	vn := &Vnode{Id: []byte{12}}
+	vn := &Vnode{ID: []byte{12}}
 	l.Register(vn, mockVN)
 
 	err := l.ClearPredecessor(vn, pred)
@@ -196,7 +197,7 @@ func TestLocalClearPred(t *testing.T) {
 		t.Fatalf("clear failed")
 	}
 
-	unknown := &Vnode{Id: []byte{1}}
+	unknown := &Vnode{ID: []byte{1}}
 	err = l.ClearPredecessor(unknown, pred)
 	if err == nil {
 		t.Fatalf("remote clear should fail")
@@ -205,12 +206,12 @@ func TestLocalClearPred(t *testing.T) {
 
 func TestLocalSkipSucc(t *testing.T) {
 	l := makeLocal()
-	suc := []*Vnode{&Vnode{Id: []byte{40}}}
+	suc := []*Vnode{{ID: []byte{40}}}
 	mockVN := &MockVnodeRPC{succ: suc}
-	vn := &Vnode{Id: []byte{12}}
+	vn := &Vnode{ID: []byte{12}}
 	l.Register(vn, mockVN)
 
-	s := &Vnode{Id: []byte{40}}
+	s := &Vnode{ID: []byte{40}}
 	err := l.SkipSuccessor(vn, s)
 	if err != nil {
 		t.Fatalf("local Skip failed")
@@ -219,7 +220,7 @@ func TestLocalSkipSucc(t *testing.T) {
 		t.Fatalf("skip failed")
 	}
 
-	unknown := &Vnode{Id: []byte{1}}
+	unknown := &Vnode{ID: []byte{1}}
 	err = l.SkipSuccessor(unknown, s)
 	if err == nil {
 		t.Fatalf("remote skip should fail")
@@ -228,7 +229,7 @@ func TestLocalSkipSucc(t *testing.T) {
 
 func TestLocalDeregister(t *testing.T) {
 	l := makeLocal()
-	vn := &Vnode{Id: []byte{1}}
+	vn := &Vnode{ID: []byte{1}}
 	mockVN := &MockVnodeRPC{}
 	l.Register(vn, mockVN)
 	if res, err := l.Ping(vn); !res || err != nil {
@@ -250,7 +251,7 @@ func TestBHList(t *testing.T) {
 
 func TestBHPing(t *testing.T) {
 	bh := BlackholeTransport{}
-	vn := &Vnode{Id: []byte{12}}
+	vn := &Vnode{ID: []byte{12}}
 	res, err := bh.Ping(vn)
 	if res || err != nil {
 		t.Fatalf("expected fail")
@@ -259,48 +260,48 @@ func TestBHPing(t *testing.T) {
 
 func TestBHGetPred(t *testing.T) {
 	bh := BlackholeTransport{}
-	vn := &Vnode{Id: []byte{12}}
+	vn := &Vnode{ID: []byte{12}}
 	_, err := bh.GetPredecessor(vn)
-	if err.Error()[:18] != "Failed to connect!" {
-		t.Fatalf("expected fail")
+	if !strings.Contains(err.Error(), "failed to connect") {
+		t.Fatalf("expected fail: '%v'", err)
 	}
 }
 
 func TestBHNotify(t *testing.T) {
 	bh := BlackholeTransport{}
-	vn := &Vnode{Id: []byte{12}}
-	vn2 := &Vnode{Id: []byte{42}}
+	vn := &Vnode{ID: []byte{12}}
+	vn2 := &Vnode{ID: []byte{42}}
 	_, err := bh.Notify(vn, vn2)
-	if err.Error()[:18] != "Failed to connect!" {
-		t.Fatalf("expected fail")
+	if !strings.Contains(err.Error(), "failed to connect") {
+		t.Fatalf("expected fail: '%v'", err)
 	}
 }
 
 func TestBHFindSuccessors(t *testing.T) {
 	bh := BlackholeTransport{}
-	vn := &Vnode{Id: []byte{12}}
+	vn := &Vnode{ID: []byte{12}}
 	_, err := bh.FindSuccessors(vn, 1, []byte("test"))
-	if err.Error()[:18] != "Failed to connect!" {
-		t.Fatalf("expected fail")
+	if !strings.Contains(err.Error(), "failed to connect") {
+		t.Fatalf("expected fail: '%v'", err)
 	}
 }
 
 func TestBHClearPred(t *testing.T) {
 	bh := BlackholeTransport{}
-	vn := &Vnode{Id: []byte{12}}
-	s := &Vnode{Id: []byte{50}}
+	vn := &Vnode{ID: []byte{12}}
+	s := &Vnode{ID: []byte{50}}
 	err := bh.ClearPredecessor(vn, s)
-	if err.Error()[:18] != "Failed to connect!" {
-		t.Fatalf("expected fail")
+	if !strings.Contains(err.Error(), "failed to connect") {
+		t.Fatalf("expected fail: '%v'", err)
 	}
 }
 
 func TestBHSkipSucc(t *testing.T) {
 	bh := BlackholeTransport{}
-	vn := &Vnode{Id: []byte{12}}
-	s := &Vnode{Id: []byte{50}}
+	vn := &Vnode{ID: []byte{12}}
+	s := &Vnode{ID: []byte{50}}
 	err := bh.SkipSuccessor(vn, s)
-	if err.Error()[:18] != "Failed to connect!" {
-		t.Fatalf("expected fail")
+	if !strings.Contains(err.Error(), "failed to connect") {
+		t.Fatalf("expected fail: '%v'", err)
 	}
 }

--- a/util.go
+++ b/util.go
@@ -75,24 +75,22 @@ func powerOffset(id []byte, exp int, mod int) []byte {
 func max(a, b int) int {
 	if a >= b {
 		return a
-	} else {
-		return b
 	}
+	return b
 }
 
 // min returns the min of two ints
 func min(a, b int) int {
 	if a <= b {
 		return a
-	} else {
-		return b
 	}
+	return b
 }
 
 // Returns the vnode nearest a key
 func nearestVnodeToKey(vnodes []*Vnode, key []byte) *Vnode {
 	for i := len(vnodes) - 1; i >= 0; i-- {
-		if bytes.Compare(vnodes[i].Id, key) == -1 {
+		if bytes.Compare(vnodes[i].ID, key) == -1 {
 			return vnodes[i]
 		}
 	}

--- a/util_test.go
+++ b/util_test.go
@@ -29,7 +29,7 @@ func TestRandStabilize(t *testing.T) {
 	for idx, val := range times {
 		for i := 0; i < len(times); i++ {
 			if idx != i && times[i] == val {
-				collisions += 1
+				collisions++
 			}
 		}
 	}
@@ -129,22 +129,22 @@ func TestMin(t *testing.T) {
 
 func TestNearestVnodesKey(t *testing.T) {
 	vnodes := make([]*Vnode, 5)
-	vnodes[0] = &Vnode{Id: []byte{2}}
-	vnodes[1] = &Vnode{Id: []byte{4}}
-	vnodes[2] = &Vnode{Id: []byte{7}}
-	vnodes[3] = &Vnode{Id: []byte{10}}
-	vnodes[4] = &Vnode{Id: []byte{14}}
+	vnodes[0] = &Vnode{ID: []byte{2}}
+	vnodes[1] = &Vnode{ID: []byte{4}}
+	vnodes[2] = &Vnode{ID: []byte{7}}
+	vnodes[3] = &Vnode{ID: []byte{10}}
+	vnodes[4] = &Vnode{ID: []byte{14}}
 	key := []byte{6}
 
 	near := nearestVnodeToKey(vnodes, key)
 	if near != vnodes[1] {
-		t.Fatalf("got wrong node back!")
+		t.Fatal("got wrong node back")
 	}
 
 	key = []byte{0}
 	near = nearestVnodeToKey(vnodes, key)
 	if near != vnodes[4] {
-		t.Fatalf("got wrong node back!")
+		t.Fatal("got wrong node back")
 	}
 }
 

--- a/vnode_test.go
+++ b/vnode_test.go
@@ -24,7 +24,7 @@ func makeVnode() *localVnode {
 func TestVnodeInit(t *testing.T) {
 	vn := makeVnode()
 	vn.init(0)
-	if vn.Id == nil {
+	if vn.ID == nil {
 		t.Fatalf("unexpected nil")
 	}
 	if vn.successors == nil {
@@ -46,12 +46,12 @@ func TestVnodeSchedule(t *testing.T) {
 	}
 }
 
-func TestGenId(t *testing.T) {
+func TestGenID(t *testing.T) {
 	vn := makeVnode()
 	var ids [][]byte
 	for i := 0; i < 16; i++ {
-		vn.genId(uint16(i))
-		ids = append(ids, vn.Id)
+		vn.genID(uint16(i))
+		ids = append(ids, vn.ID)
 	}
 
 	for idx, val := range ids {
@@ -105,7 +105,7 @@ func TestVnodeKnownSucc(t *testing.T) {
 	if vn.knownSuccessors() != 0 {
 		t.Fatalf("wrong num known!")
 	}
-	vn.successors[0] = &Vnode{Id: []byte{1}}
+	vn.successors[0] = &Vnode{ID: []byte{1}}
 	if vn.knownSuccessors() != 1 {
 		t.Fatalf("wrong num known!")
 	}
@@ -151,10 +151,10 @@ func TestVnodeCheckNewSuccAlive(t *testing.T) {
 func TestVnodeCheckNewSuccDead(t *testing.T) {
 	vn1 := makeVnode()
 	vn1.init(1)
-	vn1.successors[0] = &Vnode{Id: []byte{0}}
+	vn1.successors[0] = &Vnode{ID: []byte{0}}
 
 	if err := vn1.checkNewSuccessor(); err == nil {
-		t.Fatalf("err!", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	if vn1.successors[0].String() != "00" {
@@ -209,7 +209,8 @@ func TestVnodeCheckNewSuccAllDeadAlternates(t *testing.T) {
 	(r.transport.(*LocalTransport)).Deregister(&vn3.Vnode)
 
 	// Should get an error
-	if err := vn1.checkNewSuccessor(); err.Error() != "All known successors dead!" {
+	// if err := vn1.checkNewSuccessor(); err.Error() != "All known successors dead!" {
+	if err := vn1.checkNewSuccessor(); err != errAllKnownSuccDead {
 		t.Fatalf("unexpected err %s", err)
 	}
 
@@ -286,9 +287,9 @@ func TestVnodeNotifySucc(t *testing.T) {
 	r := makeRing()
 	sort.Sort(r)
 
-	s1 := &Vnode{Id: []byte{1}}
-	s2 := &Vnode{Id: []byte{2}}
-	s3 := &Vnode{Id: []byte{3}}
+	s1 := &Vnode{ID: []byte{1}}
+	s2 := &Vnode{ID: []byte{2}}
+	s3 := &Vnode{ID: []byte{3}}
 
 	vn1 := r.vnodes[0]
 	vn2 := r.vnodes[1]
@@ -343,9 +344,9 @@ func TestVnodeNotifySamePred(t *testing.T) {
 	r := makeRing()
 	sort.Sort(r)
 
-	s1 := &Vnode{Id: []byte{1}}
-	s2 := &Vnode{Id: []byte{2}}
-	s3 := &Vnode{Id: []byte{3}}
+	s1 := &Vnode{ID: []byte{1}}
+	s2 := &Vnode{ID: []byte{2}}
+	s3 := &Vnode{ID: []byte{3}}
 
 	vn1 := r.vnodes[0]
 	vn2 := r.vnodes[1]
@@ -377,9 +378,9 @@ func TestVnodeNotifyNoPred(t *testing.T) {
 	r := makeRing()
 	sort.Sort(r)
 
-	s1 := &Vnode{Id: []byte{1}}
-	s2 := &Vnode{Id: []byte{2}}
-	s3 := &Vnode{Id: []byte{3}}
+	s1 := &Vnode{ID: []byte{1}}
+	s2 := &Vnode{ID: []byte{2}}
+	s3 := &Vnode{ID: []byte{3}}
 
 	vn1 := r.vnodes[0]
 	vn2 := r.vnodes[1]
@@ -439,12 +440,12 @@ func TestVnodeFixFinger(t *testing.T) {
 	}
 
 	// Check we've progressed
-	if vn.last_finger != 158 {
-		t.Fatalf("unexpected last finger! %d", vn.last_finger)
+	if vn.lastFinger != 158 {
+		t.Fatalf("unexpected last finger! %d", vn.lastFinger)
 	}
 
 	// Ensure that we've setup our successor as the initial entries
-	for i := 0; i < vn.last_finger; i++ {
+	for i := 0; i < vn.lastFinger; i++ {
 		if vn.finger[i] != vn.successors[0] {
 			t.Fatalf("unexpected finger entry!")
 		}
@@ -454,8 +455,8 @@ func TestVnodeFixFinger(t *testing.T) {
 	if err := vn.fixFingerTable(); err != nil {
 		t.Fatalf("unexpected err, %s", err)
 	}
-	if vn.last_finger != 0 {
-		t.Fatalf("unexpected last finger! %d", vn.last_finger)
+	if vn.lastFinger != 0 {
+		t.Fatalf("unexpected last finger! %d", vn.lastFinger)
 	}
 }
 
@@ -613,14 +614,14 @@ func TestVnodeFindSuccessorsSomeDead(t *testing.T) {
 func TestVnodeClearPred(t *testing.T) {
 	v := makeVnode()
 	v.init(0)
-	p := &Vnode{Id: []byte{12}}
+	p := &Vnode{ID: []byte{12}}
 	v.predecessor = p
 	v.ClearPredecessor(p)
 	if v.predecessor != nil {
 		t.Fatalf("expect no predecessor!")
 	}
 
-	np := &Vnode{Id: []byte{14}}
+	np := &Vnode{ID: []byte{14}}
 	v.predecessor = p
 	v.ClearPredecessor(np)
 	if v.predecessor != p {
@@ -632,9 +633,9 @@ func TestVnodeSkipSucc(t *testing.T) {
 	v := makeVnode()
 	v.init(0)
 
-	s1 := &Vnode{Id: []byte{10}}
-	s2 := &Vnode{Id: []byte{11}}
-	s3 := &Vnode{Id: []byte{12}}
+	s1 := &Vnode{ID: []byte{10}}
+	s2 := &Vnode{ID: []byte{11}}
+	s3 := &Vnode{ID: []byte{12}}
 
 	v.successors[0] = s1
 	v.successors[1] = s2


### PR DESCRIPTION
This PR simply fixes all the linter warnings and uses go.mod.